### PR TITLE
Switch to Jobcan ID

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,5 @@
 AllCops:
   TargetRubyVersion: 2.5
+
+Metrics/AbcSize:
+  Max: 20

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    toggl-jobcan (0.1.0)
+    toggl-jobcan (0.2.0)
       chromedriver-helper
       selenium-webdriver
-      toggl-worktime (>= 0.2.0)
+      toggl-worktime (~> 0.3.0, >= 0.3.2)
 
 GEM
   remote: https://rubygems.org/
@@ -15,22 +15,22 @@ GEM
     byebug (10.0.2)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (1.2.0)
+    chromedriver-helper (2.1.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
     coderay (1.1.2)
     diff-lcs (1.3)
-    faraday (0.14.0)
+    faraday (0.15.3)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.23)
+    ffi (1.9.25)
     io-like (0.3.0)
     logger (1.2.8)
     method_source (0.9.0)
     mini_portile2 (2.3.0)
     multipart-post (2.0.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
-    oj (3.5.0)
+    oj (3.6.10)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -51,11 +51,11 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    rubyzip (1.2.1)
-    selenium-webdriver (3.11.0)
+    rubyzip (1.2.2)
+    selenium-webdriver (3.14.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
-    toggl-worktime (0.2.0)
+    toggl-worktime (0.3.2)
       awesome_print
       togglv8
     togglv8 (1.2.1)

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Prepare `~/.toggl_worktime` for [Toggl::Worktime](https://github.com/limitusus/t
 
 Prepare `~/.jobcan` YAML file that includes:
 
+From v0.3.0 you need to specify *Jobcan ID*, not *Jobcan Attendance ID*. For details read the [documentation by Jobcan](https://jobcanwf.zendesk.com/hc/ja/articles/224910508).
+
 ```yaml
-client_id: YOUR_CLIENT_ID
 email: YOUR_EMAIL_ADDRESS
 password: YOUR_PASSWORD
 ```

--- a/README.md
+++ b/README.md
@@ -14,11 +14,15 @@ gem 'toggl-jobcan'
 
 And then execute:
 
-    $ bundle
+```console
+bundle
+```
 
 Or install it yourself as:
 
-    $ gem install toggl-jobcan
+```console
+gem install toggl-jobcan
+```
 
 ## Configuration
 
@@ -59,7 +63,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/limitusus/toggl-jobcan. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at [limitusus/toggl-jobcan](https://github.com/limitusus/toggl-jobcan). This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 

--- a/exe/toggl-jobcan
+++ b/exe/toggl-jobcan
@@ -46,12 +46,12 @@ puts 'Driver ready'
 
 target_days.each do |date|
   puts "Input date: #{date}"
-  jobcan.navigate_to_attendance_modify_day(date)
   working_times = jobcan.fetch_toggl_worktime(date).flatten
   if working_times.any?(&:nil?)
     puts 'Includes nil data: skip'
     next
   end
+  jobcan.navigate_to_attendance_modify_day(date)
   jobcan.input_day_worktime(date, working_times)
   sleep 1
   puts "  - Finish: #{date}; Total time: #{jobcan.toggl.total_time}"

--- a/exe/toggl-jobcan
+++ b/exe/toggl-jobcan
@@ -22,8 +22,10 @@ opt.on('--dryrun') { |v| dryrun = v }
 opt.parse!(ARGV)
 
 raise RangeError, 'No dates given' if ARGV.empty?
+
 target_days = ARGV.map do |s|
   raise RangeError, 'Invalid format' unless s.match?(/\d#{8}/)
+
   Date.parse(s)
 end
 

--- a/lib/toggl/jobcan/client.rb
+++ b/lib/toggl/jobcan/client.rb
@@ -23,7 +23,6 @@ module Toggl
         notice: %(//textarea[@name='notice']),
         load_button: %(//input[@value='表示']),
         submit: %(//input[@type='submit']),
-        password_label: %(//label[@for='user_password']),
         flash: %(//p[@class='flash flash__alert'])
       }.freeze
 
@@ -44,9 +43,6 @@ module Toggl
 
       def login
         @driver.navigate.to JOBCAN_URLS[:login]
-        # login if <label for="user_password"> exists
-        raise unless may_find_element(:xpath, XPATHS[:password_label])
-
         send_credentials
         @driver.find_element(:xpath, XPATHS[:submit]).click
         raise JobcanLoginFailure if may_find_element(:xpath, XPATHS[:flash])

--- a/lib/toggl/jobcan/credentials.rb
+++ b/lib/toggl/jobcan/credentials.rb
@@ -6,14 +6,13 @@ module Toggl
   module Jobcan
     # Jobcan credentials manager
     class Credentials
-      attr_accessor :client_id
       attr_accessor :email
       attr_accessor :password
 
-      ATTRS = %i[client_id email password].freeze
+      ATTRS = %i[email password].freeze
 
       def initialize(args)
-        attr_set(args) if args.key?(:client_id)
+        attr_set(args) if args.key?(:email)
         c = self.class.load_config(args[:path])
         attr_set(c)
       end

--- a/toggl-jobcan.gemspec
+++ b/toggl-jobcan.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'chromedriver-helper'
   spec.add_dependency 'selenium-webdriver'
-  spec.add_dependency 'toggl-worktime', '~> 0.3.0'
+  spec.add_dependency 'toggl-worktime', '~> 0.3.0', '>= 0.3.2'
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug'


### PR DESCRIPTION
All users need to migrate from Jobcan attendance ID to Jobcan ID (ジョブカン共通ID) in Oct 2018.