### PR TITLE
webdrivers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,41 +2,34 @@ PATH
   remote: .
   specs:
     toggl-jobcan (0.3.1)
-      chromedriver-helper
       selenium-webdriver
       thor
       toggl-worktime (~> 0.3.0, >= 0.3.2)
+      webdrivers
 
 GEM
   remote: https://rubygems.org/
   specs:
-    archive-zip (0.11.0)
-      io-like (~> 0.3.0)
     awesome_print (1.8.0)
-    byebug (10.0.2)
-    childprocess (0.9.0)
-      ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (2.1.0)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
+    byebug (11.0.1)
+    childprocess (1.0.1)
+      rake (< 13.0)
     coderay (1.1.2)
     diff-lcs (1.3)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    ffi (1.10.0)
-    io-like (0.3.0)
     logger (1.3.0)
     method_source (0.9.2)
     mini_portile2 (2.4.0)
-    multipart-post (2.0.0)
-    nokogiri (1.10.1)
+    multipart-post (2.1.1)
+    nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
-    oj (3.7.8)
+    oj (3.7.12)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    pry-byebug (3.6.0)
-      byebug (~> 10.0)
+    pry-byebug (3.7.0)
+      byebug (~> 11.0)
       pry (~> 0.10)
     rake (10.5.0)
     rspec (3.8.0)
@@ -45,7 +38,7 @@ GEM
       rspec-mocks (~> 3.8.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    rspec-expectations (3.8.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-mocks (3.8.0)
@@ -53,8 +46,8 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
     rubyzip (1.2.2)
-    selenium-webdriver (3.141.0)
-      childprocess (~> 0.5)
+    selenium-webdriver (3.142.3)
+      childprocess (>= 0.5, < 2.0)
       rubyzip (~> 1.2, >= 1.2.2)
     thor (0.20.3)
     toggl-worktime (0.3.2)
@@ -64,6 +57,10 @@ GEM
       faraday
       logger
       oj
+    webdrivers (3.9.4)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
 
 PLATFORMS
   ruby

--- a/exe/toggl-jobcan
+++ b/exe/toggl-jobcan
@@ -7,8 +7,6 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'toggl/jobcan'
 
 # Default action: main
-unless %w[main version].include?(ARGV[0])
-  ARGV.unshift('main')
-end
+%w[main version help].include?(ARGV[0]) || ARGV.unshift('main')
 
 Toggl::Jobcan::Cli.start

--- a/toggl-jobcan.gemspec
+++ b/toggl-jobcan.gemspec
@@ -22,10 +22,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'chromedriver-helper'
   spec.add_dependency 'selenium-webdriver'
   spec.add_dependency 'thor'
   spec.add_dependency 'toggl-worktime', '~> 0.3.0', '>= 0.3.2'
+  spec.add_dependency 'webdrivers'
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug'


### PR DESCRIPTION
chromedriver-helper became EOL https://github.com/flavorjones/chromedriver-helper/issues/83
* Use webdrivers instead
* Update some gems to latest