### PR TITLE
Add Rubocop for code quality

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 3.1
+  NewCops: enable
 
 Metrics/AbcSize:
   Max: 20

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,3 +23,6 @@ Security/Eval:
 
 Style/HashSyntax:
   EnforcedShorthandSyntax: never
+
+Style/FormatStringToken:
+  EnforcedStyle: unannotated

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,3 +20,6 @@ Style/AccessModifierDeclarations:
 Security/Eval:
   Exclude:
     - spec/**/*.rb
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: never

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,3 +26,7 @@ Style/HashSyntax:
 
 Style/FormatStringToken:
   EnforcedStyle: unannotated
+
+Lint/ConstantDefinitionInBlock:
+  Exclude:
+    - spec/**/*.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,10 @@ Style/EvalWithLocation:
   Exclude:
     - spec/**/*.rb
 
+Style/DocumentDynamicEvalDefinition:
+  Exclude:
+    - spec/spec_helper.rb
+
 Style/AccessModifierDeclarations:
   Exclude:
     - spec/**/*.rb

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,14 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in toggl-jobcan.gemspec
 gemspec
+
+group :development do
+  gem 'bundler'
+  gem 'gem-release'
+  gem 'github_changelog_generator'
+  gem 'pry'
+  gem 'pry-byebug'
+  gem 'rake', '~> 13.0'
+  gem 'rspec', '~> 3.0'
+  gem 'rubocop'
+end

--- a/lib/toggl/jobcan/cli.rb
+++ b/lib/toggl/jobcan/cli.rb
@@ -15,8 +15,8 @@ module Toggl
       package_name 'toggl-jobcan'
       default_command :main
 
-      DEFAULT_JOBCAN_CREDENTIAL_FILE_PATH = "#{ENV.fetch('HOME', nil)}/.jobcan"
-      DEFAULT_TOGGL_WORKTIME_CONFIG_FILE_PATH = "#{ENV.fetch('HOME', nil)}/.toggl_worktime"
+      DEFAULT_JOBCAN_CREDENTIAL_FILE_PATH = "#{Dir.home}/.jobcan".freeze
+      DEFAULT_TOGGL_WORKTIME_CONFIG_FILE_PATH = "#{Dir.home}/.toggl_worktime".freeze
 
       desc(
         '[options] DATE [DATE...]',
@@ -78,7 +78,7 @@ module Toggl
 
             Date.parse(s)
           end
-          raise NoDayGivenError if @target_days.size.zero?
+          raise NoDayGivenError if @target_days.empty?
         end
 
         def prepare_jobcan
@@ -109,7 +109,7 @@ module Toggl
           day = @target_days.first
           y = day.year
           m = day.month
-          return if @target_days.all? { |d| d.year == y and d.month == m }
+          return if @target_days.all? { |d| (d.year == y) && (d.month == m) }
 
           raise DifferentYearMonthError, "Different year/month=#{d.year}/#{d.month}"
         end

--- a/lib/toggl/jobcan/cli.rb
+++ b/lib/toggl/jobcan/cli.rb
@@ -15,8 +15,8 @@ module Toggl
       package_name 'toggl-jobcan'
       default_command :main
 
-      DEFAULT_JOBCAN_CREDENTIAL_FILE_PATH = "#{ENV['HOME']}/.jobcan"
-      DEFAULT_TOGGL_WORKTIME_CONFIG_FILE_PATH = "#{ENV['HOME']}/.toggl_worktime"
+      DEFAULT_JOBCAN_CREDENTIAL_FILE_PATH = "#{ENV.fetch('HOME', nil)}/.jobcan"
+      DEFAULT_TOGGL_WORKTIME_CONFIG_FILE_PATH = "#{ENV.fetch('HOME', nil)}/.toggl_worktime"
 
       desc(
         '[options] DATE [DATE...]',
@@ -109,9 +109,9 @@ module Toggl
           day = @target_days.first
           y = day.year
           m = day.month
-          unless @target_days.all? { |d| d.year == y and d.month == m }
-            raise DifferentYearMonthError, "Different year/month=#{d.year}/#{d.month}"
-          end
+          return if @target_days.all? { |d| d.year == y and d.month == m }
+
+          raise DifferentYearMonthError, "Different year/month=#{d.year}/#{d.month}"
         end
 
         def register_days

--- a/lib/toggl/jobcan/client.rb
+++ b/lib/toggl/jobcan/client.rb
@@ -32,7 +32,7 @@ module Toggl
       )
         @credentials = credentials
         options.add_argument('--headless')
-        @driver = Selenium::WebDriver.for(:chrome, options:)
+        @driver = Selenium::WebDriver.for(:chrome, options: options)
         @toggl = Toggl::Worktime::Driver.new(
           config: Toggl::Worktime::Config.new(path: toggl_worktime_config)
         )
@@ -75,7 +75,7 @@ module Toggl
       def navigate_to_attendance_modify_day(date)
         # https://ssl.jobcan.jp/employee/adit/modify?year=2018&month=3&day=14
         query_string = "year=#{date.year}&month=#{date.month}&day=#{date.day}"
-        @driver.navigate.to JOBCAN_URLS[:attendance_modify] + '?' + query_string
+        @driver.navigate.to "#{JOBCAN_URLS[:attendance_modify]}?#{query_string}"
       end
 
       def select_support_for(name)

--- a/lib/toggl/jobcan/client.rb
+++ b/lib/toggl/jobcan/client.rb
@@ -5,8 +5,7 @@ module Toggl
     # Jobcan client
     class Client
       attr_accessor :credentials
-      attr_reader :driver
-      attr_reader :toggl
+      attr_reader :driver, :toggl
 
       class JobcanLoginFailure < StandardError; end
 
@@ -27,14 +26,13 @@ module Toggl
       }.freeze
 
       def initialize(
-            credentials: nil,
-            options: Selenium::WebDriver::Chrome::Options.new,
-            toggl_worktime_config:,
-            dryrun: false
-          )
+        toggl_worktime_config:, credentials: nil,
+        options: Selenium::WebDriver::Chrome::Options.new,
+        dryrun: false
+      )
         @credentials = credentials
         options.add_argument('--headless')
-        @driver = Selenium::WebDriver.for :chrome, options: options
+        @driver = Selenium::WebDriver.for(:chrome, options:)
         @toggl = Toggl::Worktime::Driver.new(
           config: Toggl::Worktime::Config.new(path: toggl_worktime_config)
         )

--- a/lib/toggl/jobcan/credentials.rb
+++ b/lib/toggl/jobcan/credentials.rb
@@ -25,7 +25,7 @@ module Toggl
       private
 
       def attr_set(hash)
-        ATTRS.each { |k| send((k.to_s + '=').to_sym, hash[k]) }
+        ATTRS.each { |k| send("#{k}=".to_sym, hash[k]) }
       end
     end
   end

--- a/lib/toggl/jobcan/credentials.rb
+++ b/lib/toggl/jobcan/credentials.rb
@@ -6,8 +6,7 @@ module Toggl
   module Jobcan
     # Jobcan credentials manager
     class Credentials
-      attr_accessor :email
-      attr_accessor :password
+      attr_accessor :email, :password
 
       ATTRS = %i[email password].freeze
 
@@ -19,7 +18,7 @@ module Toggl
 
       class << self
         def load_config(path)
-          YAML.safe_load(File.open(path).read).transform_keys(&:to_sym)
+          YAML.safe_load(File.read(path)).transform_keys(&:to_sym)
         end
       end
 

--- a/lib/toggl/jobcan/toggl_support.rb
+++ b/lib/toggl/jobcan/toggl_support.rb
@@ -5,8 +5,8 @@ module Toggl
     # Provides support methods for Toggl
     module TogglSupport
       def fetch_toggl_worktime(dates)
-        first_day = dates.sort.first
-        last_day = dates.sort.last
+        first_day = dates.min
+        last_day = dates.max
         @toggl.merge_multi!(first_day.year, first_day.month, first_day.day, last_day.day)
         @toggl.work_time_map
       end

--- a/spec/toggl/jobcan_cli_spec.rb
+++ b/spec/toggl/jobcan_cli_spec.rb
@@ -59,12 +59,12 @@ RSpec.describe Toggl::Jobcan::Cli do
         ]
         expected_days_expr = expected_days.map do |d|
           "  - #{d}\n"
-        end.join('')
+        end.join
         expect(
           capture(:stdout) do
             cli_class.start(['--days', *days])
           end
-        ).to eq 'Target days:' + "\n" + expected_days_expr
+        ).to eq "Target days:\n#{expected_days_expr}"
       end
     end
 

--- a/spec/toggl/jobcan_cli_spec.rb
+++ b/spec/toggl/jobcan_cli_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Toggl::Jobcan::Cli do
         allow_any_instance_of(cli_class).to receive(:jobcan) do
           JobcanMock.new
         end
-        allow_any_instance_of(cli_class).to receive(:register_day) do |_client, map, date|
+        allow_any_instance_of(cli_class).to receive(:register_day) do |_client, _map, date|
           args << date
         end
       end

--- a/toggl-jobcan.gemspec
+++ b/toggl-jobcan.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |spec|
   spec.description   = 'Sync toggl worktime to JobCan.'
   spec.homepage      = 'https://github.com/limitusus/toggl-jobcan'
   spec.license       = 'MIT'
+  spec.required_ruby_version = '>= 3.1'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
@@ -26,5 +28,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor'
   spec.add_dependency 'toggl-worktime', '~> 0.7.0', '>= 0.7.0'
   spec.add_dependency 'webdrivers'
-  spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/toggl-jobcan.gemspec
+++ b/toggl-jobcan.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rubocop'
 end

--- a/toggl-jobcan.gemspec
+++ b/toggl-jobcan.gemspec
@@ -26,13 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor'
   spec.add_dependency 'toggl-worktime', '~> 0.7.0', '>= 0.7.0'
   spec.add_dependency 'webdrivers'
-  spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'gem-release'
-  spec.add_development_dependency 'github_changelog_generator'
-  spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'pry-byebug'
-  spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/toggl-jobcan.gemspec
+++ b/toggl-jobcan.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
## Summary
- Add rubocop as development dependency
- Update rubocop config for Ruby 3.1 with NewCops enabled
- Apply auto-corrections and configure cop exclusions
- Move development dependencies from gemspec to Gemfile
- Specify required_ruby_version >= 3.1

## Remaining violation
- `Metrics/ClassLength` in `lib/toggl/jobcan/cli.rb` (108/100 lines)

## Test plan
- [x] `bundle exec rspec` passes
- [x] `bundle exec rubocop` shows only 1 known violation