### PR TITLE
Migrate from Selenium to Ferrum

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ RUN rbenv install 3.1.4
 RUN rbenv global 3.1.4
 
 # toggl-jobcan
-RUN gem install selenium-webdriver -v 4.21.1
 RUN gem install toggl-jobcan
 
 ENTRYPOINT ["toggl-jobcan"]

--- a/lib/toggl/jobcan/cli.rb
+++ b/lib/toggl/jobcan/cli.rb
@@ -2,7 +2,7 @@
 
 require 'thor'
 require 'optparse'
-require 'selenium-webdriver'
+require 'ferrum'
 
 module Toggl
   module Jobcan

--- a/toggl-jobcan.gemspec
+++ b/toggl-jobcan.gemspec
@@ -24,8 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'selenium-webdriver'
+  spec.add_dependency 'ferrum'
   spec.add_dependency 'thor'
   spec.add_dependency 'toggl-worktime', '~> 0.7.0', '>= 0.7.0'
-  spec.add_dependency 'webdrivers'
 end


### PR DESCRIPTION
## Summary

- Migrate from Selenium to Ferrum for Chrome DevTools Protocol-based browser control
- Replace `selenium-webdriver` and `webdrivers` gems with `ferrum`
- Remove unused methods (`send_notice`, `select_support_for`, `may_find_element`)

## Changes

| File | Change |
|------|--------|
| `toggl-jobcan.gemspec` | `selenium-webdriver`, `webdrivers` → `ferrum` |
| `lib/toggl/jobcan/cli.rb` | Update require statement |
| `lib/toggl/jobcan/client.rb` | Migrate to Ferrum API |
| `Dockerfile` | Remove `selenium-webdriver` installation |

## API Mapping

| Operation | Selenium | Ferrum |
|-----------|----------|--------|
| Navigation | `driver.navigate.to(url)` | `driver.goto(url)` |
| Find by XPath | `driver.find_element(:xpath, path)` | `driver.at_xpath(path)` |
| Find by ID | `driver.find_element(:id, id)` | `driver.at_css("##{id}")` |
| Text input | `element.send_keys(text)` | `element.focus.type(text)` |
| Select | `Select.new(el).select_by(:text, val)` | `element.select(val, by: :text)` |

## Test plan

- [x] Verify `ferrum` is installed via `bundle install`
- [x] Verify Jobcan login works locally